### PR TITLE
Time punch page fix

### DIFF
--- a/src/ui/work-schedule/widgets/pages/time-punch/index.tsx
+++ b/src/ui/work-schedule/widgets/pages/time-punch/index.tsx
@@ -18,15 +18,12 @@ export const TimePunchPage = ({ workdayLog, collaborationName }: TimePunchPagePr
     currentTime,
     completeDate,
     currentPeriod,
-    currentTimeSchedule,
     periods,
     step,
-    timesLog,
+    times,
     isClosed,
-    timesSchedule,
     isPuchingTime,
-    handlePunchRegister,
-    handleTimePunchLogConfirm,
+    handleTimePunchConfirm,
   } = useTimePunchPage(workdayLog)
 
   return (
@@ -48,8 +45,7 @@ export const TimePunchPage = ({ workdayLog, collaborationName }: TimePunchPagePr
           currentStep={step}
           periods={periods}
           isClosed={isClosed}
-          timesSchedule={timesSchedule}
-          timesLog={timesLog}
+          times={times}
         />
 
         <div className='mt-8'>
@@ -69,16 +65,13 @@ export const TimePunchPage = ({ workdayLog, collaborationName }: TimePunchPagePr
                 </p>
               </Button>
             }
-            onConfirm={handleTimePunchLogConfirm}
+            onConfirm={handleTimePunchConfirm}
           >
             <div className='mx-auto w-max'>
-              <p className='text-lg'>
-                <strong className='font-normal'>{currentPeriod}</strong>:{' '}
-                <time className='ml-1 border-b border-slate-900'>
-                  {currentTimeSchedule}
-                </time>
-              </p>
-              <p className='text-lg mt-3 mb-3'>
+              <strong className='block w-full text-xl font-normal text-center'>
+                {currentPeriod}
+              </strong>
+              <p className='text-lg mt-6 mb-3'>
                 <strong className='font-semibold'>Seu horário:</strong>
                 <time className='ml-3 mx-auto w-max text-3xl font-bold border-b border-slate-900'>
                   {currentTime}

--- a/src/ui/work-schedule/widgets/pages/time-punch/time-stepper/index.tsx
+++ b/src/ui/work-schedule/widgets/pages/time-punch/time-stepper/index.tsx
@@ -3,16 +3,14 @@ import { Time } from '../../../components/time'
 type TimePunchStepperProps = {
   currentStep: number
   isClosed: boolean
-  timesSchedule: string[]
-  timesLog: string[]
+  times: string[]
   periods: string[]
 }
 
 export const TimePunchStepper = ({
   currentStep,
   isClosed,
-  timesSchedule,
-  timesLog,
+  times,
   periods,
 }: TimePunchStepperProps) => {
   return (
@@ -49,11 +47,7 @@ export const TimePunchStepper = ({
               }
             `}
           />
-
-          <Time className='my-3 text-sm font-bold text-black'>
-            {timesSchedule[index]}
-          </Time>
-          <Time>{timesLog[index]}</Time>
+          <Time className='mt-6'>{times[index]}</Time>
         </div>
       ))}
     </div>

--- a/src/ui/work-schedule/widgets/pages/time-punch/use-time-punch-page.ts
+++ b/src/ui/work-schedule/widgets/pages/time-punch/use-time-punch-page.ts
@@ -20,61 +20,40 @@ export function useTimePunchPage(workdayLog: WorkdayLogDto) {
   }, [])
 
   useEffect(() => {
-    if (workdayLog.timePunchLog.firstClockIn) {
+    if (workdayLog.timePunch.firstClockIn) {
       setStep(1)
     }
-    if (workdayLog.timePunchLog.firstClockOut) {
+    if (workdayLog.timePunch.firstClockOut) {
       setStep(2)
     }
-    if (workdayLog.timePunchLog.secondClockIn) {
+    if (workdayLog.timePunch.secondClockIn) {
       setStep(3)
     }
-    if (workdayLog.timePunchLog.secondClockOut) {
+    if (workdayLog.timePunch.secondClockOut) {
       setStep(4)
     }
   }, [workdayLog])
 
-  function handlePunchRegister() {
-    const newStep = step + 1
-    if (newStep > 4) {
-      setStep(1)
-    } else {
-      setStep(newStep)
-    }
+  async function handleTimePunchConfirm() {
+    if (workdayLog.timePunch.id) await punchTime(workdayLog.timePunch.id, currentTime)
   }
 
-  async function handleTimePunchLogConfirm() {
-    await punchTime(workdayLog.timePunchLog.id, currentTime)
-  }
-
-  const timesSchedule = [
-    workdayLog.timePunchSchedule.firstClockIn,
-    workdayLog.timePunchSchedule.firstClockOut,
-    workdayLog.timePunchSchedule.secondClockIn,
-    workdayLog.timePunchSchedule.secondClockOut,
-  ].map(datetimeProvider.formatTime)
-
-  const timesLog = [
-    workdayLog.timePunchLog.firstClockIn,
-    workdayLog.timePunchLog.firstClockOut,
-    workdayLog.timePunchLog.secondClockIn,
-    workdayLog.timePunchLog.secondClockOut,
-  ]
-    .filter(Boolean)
-    .map(datetimeProvider.formatTime)
+  const times = [
+    workdayLog.timePunch.firstClockIn,
+    workdayLog.timePunch.firstClockOut,
+    workdayLog.timePunch.secondClockIn,
+    workdayLog.timePunch.secondClockOut,
+  ].map((time) => (time ? datetimeProvider.formatTime(time) : ''))
 
   return {
     currentTime: datetimeProvider.formatTime(currentTime),
     completeDate: datetimeProvider.formatCompleteDate(currentTime),
     step,
     isClosed: step === 4,
-    timesSchedule,
-    timesLog,
+    times,
     currentPeriod: PERIODS[step],
-    currentTimeSchedule: timesSchedule[step],
     periods: PERIODS,
     isPuchingTime,
-    handlePunchRegister,
-    handleTimePunchLogConfirm,
+    handleTimePunchConfirm,
   }
 }


### PR DESCRIPTION
## 🐞 Bug Fix

### 🔀 Branch

`time-punch-page-fix`

### Main purpose

The time punch page was not adapted for the work schedule refactor.

### How was it fixed?

The reference to both `timePunchSchedule` and `timePunchLog ` was removed, as only `timePunchSchedule` exists in the module (now referred to simply as timePunch)

### Changelog

- Removed extra time punch prop from the time punch page

### How to test

Access the time punch page and try to register a punch — everything should work as expected.

### Checklist

- [ x ] Verified the bug is resolved
- [ x ] Existing functionality remains unchanged
